### PR TITLE
Fail resilient status

### DIFF
--- a/app/models/bathroom.rb
+++ b/app/models/bathroom.rb
@@ -1,5 +1,5 @@
 class Bathroom < ActiveRecord::Base
-  enum status: [:occupied, :available]
+  enum status: [:available, :occupied]
 
   validates :name, presence: true
   validates :sparkcore_id, presence: true, uniqueness: true

--- a/app/models/bathroom.rb
+++ b/app/models/bathroom.rb
@@ -1,5 +1,5 @@
 class Bathroom < ActiveRecord::Base
-  enum status: [:available, :occupied]
+  enum status: [:available, :occupied, :unknown]
 
   validates :name, presence: true
   validates :sparkcore_id, presence: true, uniqueness: true

--- a/bin/monitor
+++ b/bin/monitor
@@ -30,18 +30,29 @@ else
   uri = URI('https://api.spark.io/v1/events/door')
   http = Net::HTTP.new(uri.host, uri.port)
   http.use_ssl = true
+  http.read_timeout = 5
+
+  # Give the websever time to start up, or it'll miss the events
+  # we send.
+  sleep(2)
 
   Bathroom.all.each do |bathroom|
-    uri2 = URI("https://api.spark.io/v1/devices/#{bathroom.sparkcore_id}/state")
-    req = Net::HTTP::Get.new(uri2)
-    req["Authorization"] = "Bearer #{ENV['SPARK_AUTH_TOKEN']}"
-    req["Content-Type"]  = "application/json"
-    res = http.request(req)
-    data = JSON.parse(res.body)
-    bathroom.update_attributes(status: data['result'])
-    puts "Set #{bathroom.name} to #{bathroom.status}."
+    begin
+      uri2 = URI("https://api.spark.io/v1/devices/#{bathroom.sparkcore_id}/state")
+      req = Net::HTTP::Get.new(uri2)
+      req["Authorization"] = "Bearer #{ENV['SPARK_AUTH_TOKEN']}"
+      req["Content-Type"]  = "application/json"
+      res = http.request(req)
+      data = JSON.parse(res.body)
+      bathroom.update_attributes(status: data['result'])
+    rescue
+      bathroom.update_attributes(status: :unknown)
+    ensure
+      puts "Set #{bathroom.name} to #{bathroom.status}."
+    end
   end
 
+  http.read_timeout = 60
   req = Net::HTTP::Get.new(uri)
   req["Authorization"] = "Bearer #{ENV['SPARK_AUTH_TOKEN']}"
   req["Content-Type"]  = "application/json"

--- a/bin/monitor
+++ b/bin/monitor
@@ -30,6 +30,18 @@ else
   uri = URI('https://api.spark.io/v1/events/door')
   http = Net::HTTP.new(uri.host, uri.port)
   http.use_ssl = true
+
+  Bathroom.all.each do |bathroom|
+    uri2 = URI("https://api.spark.io/v1/devices/#{bathroom.sparkcore_id}/state")
+    req = Net::HTTP::Get.new(uri2)
+    req["Authorization"] = "Bearer #{ENV['SPARK_AUTH_TOKEN']}"
+    req["Content-Type"]  = "application/json"
+    res = http.request(req)
+    data = JSON.parse(res.body)
+    bathroom.update_attributes(status: data['result'])
+    puts "Set #{bathroom.name} to #{bathroom.status}."
+  end
+
   req = Net::HTTP::Get.new(uri)
   req["Authorization"] = "Bearer #{ENV['SPARK_AUTH_TOKEN']}"
   req["Content-Type"]  = "application/json"

--- a/firmware/application.cpp
+++ b/firmware/application.cpp
@@ -3,9 +3,8 @@ char *ssid;
 // State
 // 0 = Available
 // 1 = Occupied
-// 2 = Unknown
-int state      = 2;
-int last_state = 2;
+int state;
+int last_state = state;
 
 void setup() {
   pinMode(D7, OUTPUT);
@@ -13,6 +12,8 @@ void setup() {
 
   ssid = Network.SSID();
   Spark.variable("ssid", ssid, STRING);
+
+  state = digitalRead(D0);
   Spark.variable("state", &state, INT);
 }
 

--- a/firmware/application.cpp
+++ b/firmware/application.cpp
@@ -1,5 +1,3 @@
-char *ssid;
-
 // State
 // 0 = Available
 // 1 = Occupied
@@ -10,7 +8,10 @@ void setup() {
   pinMode(D7, OUTPUT);
   pinMode(D0, INPUT_PULLDOWN);
 
-  ssid = Network.SSID();
+  char *version = "0.0.3";
+  Spark.variable("version", version, STRING);
+
+  char *ssid = Network.SSID();
   Spark.variable("ssid", ssid, STRING);
 
   state = digitalRead(D0);

--- a/firmware/application.cpp
+++ b/firmware/application.cpp
@@ -1,7 +1,11 @@
-#include "application.h"
-
 char *ssid;
-int last_state = -1;
+
+// State
+// 0 = Available
+// 1 = Occupied
+// 2 = Unknown
+int state      = 2;
+int last_state = 2;
 
 void setup() {
   pinMode(D7, OUTPUT);
@@ -9,10 +13,11 @@ void setup() {
 
   ssid = Network.SSID();
   Spark.variable("ssid", ssid, STRING);
+  Spark.variable("state", &state, INT);
 }
 
 void loop() {
-  int state = digitalRead(D0);
+  state = digitalRead(D0);
 
   if (state != last_state) {
     digitalWrite(D7, state);


### PR DESCRIPTION
Query the core when starting the monitor for the current state. The core is in charge of setting it's state. This addresses #4.

TODO:
- [x] Error handling case (return 2)
- [x] Decide on best option for `status_updated_at`
